### PR TITLE
Allow mind map nodes to grow with content

### DIFF
--- a/script.js
+++ b/script.js
@@ -18,16 +18,15 @@ let nextId = 0;
 // Visual sizing constants shared by the renderer. Keeping the node dimensions
 // in a single place makes it easier to tune the layout when tweaking the
 // appearance.
-const NODE_WIDTH = 200;
-const NODE_HEIGHT = 80;
+const NODE_MAX_WIDTH = 220;
+const DEFAULT_NODE_HEIGHT = 80;
 const NODE_MARGIN_X = 80;
-const NODE_MARGIN_Y = 40;
+const NODE_VERTICAL_GAP = 24;
 
-// Spacing constants derived from the node geometry. By tying the distances to
-// the node dimensions we ensure that horizontal/vertical spacing is always
-// sufficient to avoid overlap, even when the node width or height changes.
-const H_SPACING = NODE_WIDTH + NODE_MARGIN_X; // horizontal distance between generations
-const V_SPACING = NODE_HEIGHT + NODE_MARGIN_Y; // vertical distance between siblings
+// Spacing constants derived from the node geometry. By tying the horizontal
+// spacing to the node's maximum width, we guarantee that branches stay clear of
+// each other even when text boxes expand vertically to fit their content.
+const H_SPACING = NODE_MAX_WIDTH + NODE_MARGIN_X; // horizontal distance between generations
 
 // D3 selection for the SVG container.
 let svg;
@@ -48,6 +47,64 @@ const BRANCH_COLORS = [
   '#E91E63', // pink
   '#3F51B5'  // indigo
 ];
+
+// Cache of measured node sizes (in pixels) keyed by node id. Sizes are updated
+// after every render to keep the layout in sync with the text content.
+const nodeSizeCache = new Map();
+
+// Debounced scheduling helpers so layout updates triggered by size changes do
+// not cause synchronous recursion. Using requestAnimationFrame allows the DOM
+// to settle before we measure boxes or perform another render pass.
+const scheduleFrame = (typeof window !== 'undefined' && window.requestAnimationFrame)
+  ? (callback) => window.requestAnimationFrame(callback)
+  : (callback) => setTimeout(callback, 16);
+
+let renderScheduled = false;
+let measurementScheduled = false;
+
+function scheduleRender() {
+  if (renderScheduled) return;
+  renderScheduled = true;
+  scheduleFrame(() => {
+    renderScheduled = false;
+    renderMindMap();
+  });
+}
+
+function scheduleMeasurement() {
+  if (measurementScheduled) return;
+  measurementScheduled = true;
+  scheduleFrame(() => {
+    measurementScheduled = false;
+    const changed = updateNodeSizeCache();
+    if (changed) {
+      scheduleRender();
+    }
+  });
+}
+
+function getNodeBoxSize(node) {
+  const cached = nodeSizeCache.get(node.id);
+  if (cached) {
+    return cached;
+  }
+  return { width: NODE_MAX_WIDTH, height: DEFAULT_NODE_HEIGHT };
+}
+
+function getNodeLayoutHeight(node) {
+  const { height } = getNodeBoxSize(node);
+  return height + NODE_VERTICAL_GAP;
+}
+
+function getClampedBoxWidth(node) {
+  const { width } = getNodeBoxSize(node);
+  return Math.min(Math.max(width, 80), NODE_MAX_WIDTH);
+}
+
+function getClampedBoxHeight(node) {
+  const { height } = getNodeBoxSize(node);
+  return Math.max(height, 40);
+}
 
 // Open or create the IndexedDB database.
 function openDB() {
@@ -159,19 +216,43 @@ function computeWeights(node) {
 function assignSidePositions(node, depth, yStart, posMap) {
   const current = { depth, y: 0, height: 0 };
   posMap[node.id] = current;
+  const nodeHeight = getNodeLayoutHeight(node);
   if (!node.children || node.children.length === 0) {
-    current.height = 1;
-    current.y = yStart + 0.5;
-    return 1;
+    current.height = nodeHeight;
+    current.y = yStart + nodeHeight / 2;
+    return current.height;
   }
   let y = yStart;
   for (const child of node.children) {
     const childHeight = assignSidePositions(child, depth + 1, y, posMap);
     y += childHeight;
   }
-  current.height = y - yStart;
-  current.y = (yStart + y) / 2;
+  const totalChildHeight = y - yStart;
+  const requiredHeight = Math.max(totalChildHeight, nodeHeight);
+  current.height = requiredHeight;
+  const extra = requiredHeight - totalChildHeight;
+  if (extra > 0 && totalChildHeight > 0) {
+    let childStart = yStart + extra / 2;
+    for (const child of node.children) {
+      const childInfo = posMap[child.id];
+      const desiredCenter = childStart + childInfo.height / 2;
+      const delta = desiredCenter - childInfo.y;
+      if (Math.abs(delta) > 0.1) {
+        shiftSubtree(child, posMap, delta);
+      }
+      childStart += childInfo.height;
+    }
+  }
+  current.y = yStart + requiredHeight / 2;
   return current.height;
+}
+
+function shiftSubtree(node, posMap, delta) {
+  const info = posMap[node.id];
+  info.y += delta;
+  if (node.children && node.children.length) {
+    node.children.forEach(child => shiftSubtree(child, posMap, delta));
+  }
 }
 
 // Compute the final x,y coordinates for all nodes.
@@ -204,21 +285,27 @@ function computePositions() {
   const posLeft = {};
   let yStartLeft = 0;
   leftChildren.forEach(child => {
-    assignSidePositions(child, 0, yStartLeft, posLeft);
-    yStartLeft += child.weight;
+    const branchHeight = assignSidePositions(child, 0, yStartLeft, posLeft);
+    yStartLeft += branchHeight;
   });
   // Assign positions for right side.
   const posRight = {};
   let yStartRight = 0;
   rightChildren.forEach(child => {
-    assignSidePositions(child, 0, yStartRight, posRight);
-    yStartRight += child.weight;
+    const branchHeight = assignSidePositions(child, 0, yStartRight, posRight);
+    yStartRight += branchHeight;
   });
   // Normalise root child positions so both sides align at y=0.
   const rootLeftY = leftChildren.length > 0 ? posLeft[leftChildren[0].id].y : 0;
   const rootRightY = rightChildren.length > 0 ? posRight[rightChildren[0].id].y : 0;
   // Compute final positions. Root at (0,0).
-  positions[rootNode.id] = { x: 0, y: 0, node: rootNode };
+  positions[rootNode.id] = {
+    x: 0,
+    y: 0,
+    node: rootNode,
+    height: getNodeLayoutHeight(rootNode),
+    box: getNodeBoxSize(rootNode)
+  };
   // Process left side.
   leftChildren.forEach(child => {
     traverseAssignFinal(child, 'left', posLeft, positions, rootLeftY);
@@ -234,13 +321,40 @@ function traverseAssignFinal(node, side, posMap, finalMap, rootY) {
   const info = posMap[node.id];
   const yNorm = info.y - rootY;
   const x = (info.depth + 1) * H_SPACING * (side === 'left' ? -1 : 1);
-  const y = yNorm * V_SPACING;
-  finalMap[node.id] = { x, y, node };
+  const y = yNorm;
+  finalMap[node.id] = { x, y, node, height: info.height, box: getNodeBoxSize(node) };
   if (node.children) {
     node.children.forEach(child => {
       traverseAssignFinal(child, side, posMap, finalMap, rootY);
     });
   }
+}
+
+function updateNodeSizeCache() {
+  let changed = false;
+  const elements = document.querySelectorAll('.node-text');
+  elements.forEach(div => {
+    const id = parseInt(div.dataset.nodeId, 10);
+    if (Number.isNaN(id)) return;
+    const fo = div.closest('foreignObject');
+    const foRect = fo ? fo.getBoundingClientRect() : null;
+    const attrWidth = fo ? parseFloat(fo.getAttribute('width')) || NODE_MAX_WIDTH : NODE_MAX_WIDTH;
+    const attrHeight = fo ? parseFloat(fo.getAttribute('height')) || DEFAULT_NODE_HEIGHT : DEFAULT_NODE_HEIGHT;
+    const scaleX = foRect && foRect.width ? attrWidth / foRect.width : 1;
+    const scaleY = foRect && foRect.height ? attrHeight / foRect.height : 1;
+    const rawWidth = Math.max(div.scrollWidth, div.offsetWidth);
+    const rawHeight = Math.max(div.scrollHeight, div.offsetHeight);
+    const measuredWidth = rawWidth * scaleX;
+    const measuredHeight = rawHeight * scaleY;
+    const width = Math.min(Math.max(measuredWidth, 80), NODE_MAX_WIDTH);
+    const height = Math.max(measuredHeight, 40);
+    const prev = nodeSizeCache.get(id);
+    if (!prev || Math.abs(prev.width - width) > 0.5 || Math.abs(prev.height - height) > 0.5) {
+      nodeSizeCache.set(id, { width, height });
+      changed = true;
+    }
+  });
+  return changed;
 }
 
 // Render the mind map based on the current rootNode.
@@ -257,11 +371,29 @@ function renderMindMap() {
   let maxX = -Infinity;
   let minY = Infinity;
   let maxY = -Infinity;
-  Object.values(positions).forEach(({ x, y }) => {
-    if (x < minX) minX = x;
-    if (x > maxX) maxX = x;
-    if (y < minY) minY = y;
-    if (y > maxY) maxY = y;
+  Object.values(positions).forEach(pos => {
+    const { x, y } = pos;
+    const width = getClampedBoxWidth(pos.node);
+    const height = getClampedBoxHeight(pos.node);
+    const halfHeight = height / 2;
+    const top = y - halfHeight;
+    const bottom = y + halfHeight;
+    if (top < minY) minY = top;
+    if (bottom > maxY) maxY = bottom;
+    const circleRadius = 10;
+    const circleLeft = x - circleRadius;
+    const circleRight = x + circleRadius;
+    let left = circleLeft;
+    let right = circleRight;
+    if (x >= 0) {
+      left = Math.min(left, x + 12);
+      right = Math.max(right, x + 12 + width);
+    } else {
+      left = Math.min(left, x - (width + 12));
+      right = Math.max(right, x - 12);
+    }
+    if (left < minX) minX = left;
+    if (right > maxX) maxX = right;
   });
   const rootPosition = positions[rootNode.id] || { y: 0 };
   const topSpace = rootPosition.y - minY;
@@ -271,14 +403,8 @@ function renderMindMap() {
   } else {
     maxY = rootPosition.y + topSpace;
   }
-  // Extend the horizontal range to accommodate label boxes that extend beyond
-  // the node positions. Each label spans NODE_WIDTH pixels plus the 12px offset
-  // applied during rendering, so we add padding before computing the viewBox.
-  // Without this, labels on the left side can be clipped outside the viewBox
-  // and become invisible.
-  const labelPad = NODE_WIDTH + 32;
-  minX -= labelPad;
-  maxX += labelPad;
+  // Extend the computed bounds with extra padding so node shadows and expanded
+  // text boxes remain fully visible after zooming or exporting.
   const margin = 60;
   const width = maxX - minX || 1;
   const height = maxY - minY || 1;
@@ -352,12 +478,12 @@ function renderMindMap() {
     .on('click', function(event, d) {
       focusOnNode(d.node.id);
     });
-  // Append foreignObject for editable text using a fixed-size box so layout math
-  // can assume consistent dimensions.
+  // Append foreignObject for editable text. The width is limited by a maximum
+  // value but the height grows with the content, so nodes expand naturally.
   const fo = nodeEnter.append('foreignObject')
     .attr('class', 'node-fo')
-    .attr('width', NODE_WIDTH)
-    .attr('height', NODE_HEIGHT);
+    .attr('width', NODE_MAX_WIDTH)
+    .attr('height', DEFAULT_NODE_HEIGHT);
   // Also attach click handler on the foreignObject itself so that clicking on empty
   // space within it will still focus the node.
   fo.on('click', function(event, d) {
@@ -371,14 +497,16 @@ function renderMindMap() {
     // long words break appropriately instead of overflowing into other nodes.
     .style('white-space', 'normal')
     .style('overflow-wrap', 'anywhere')
-    .style('overflow-y', 'auto')
-    .style('width', '100%')
-    .style('height', '100%')
+    .style('overflow-y', 'visible')
+    .style('display', 'inline-block')
+    .style('width', 'auto')
+    .style('max-width', '100%')
+    .style('min-width', '80px')
+    .style('height', 'auto')
     .style('padding', '8px')
     .style('box-sizing', 'border-box')
     .style('border-radius', '10px')
     .style('background', '#ffffff')
-    .style('border', '1px solid rgba(74, 144, 226, 0.35)')
     .style('box-shadow', '0 2px 6px rgba(15, 23, 42, 0.12)')
     .style('line-height', '1.3')
     .style('outline', 'none')
@@ -393,10 +521,15 @@ function renderMindMap() {
     // Position the editable text box to the right of the circle for right‑side nodes
     // and to the left for left‑side nodes. The offset mirrors the node width to
     // keep spacing symmetric.
-    .attr('width', NODE_WIDTH)
-    .attr('height', NODE_HEIGHT)
-    .attr('x', d => (d.x >= 0 ? 12 : -(NODE_WIDTH + 12)))
-    .attr('y', -(NODE_HEIGHT / 2));
+    .each(function(d) {
+      const width = getClampedBoxWidth(d.node);
+      const height = getClampedBoxHeight(d.node);
+      d3.select(this)
+        .attr('width', width)
+        .attr('height', height)
+        .attr('x', d.x >= 0 ? 12 : -(width + 12))
+        .attr('y', -(height / 2));
+    });
   nodeSel.merge(nodeEnter).select('.node-text')
     .each(function(d) {
       const div = this;
@@ -429,8 +562,10 @@ function renderMindMap() {
       if (node) {
         node.text = this.textContent;
       }
+      scheduleMeasurement();
     });
   nodeSel.exit().remove();
+  scheduleMeasurement();
   // Update hidden markdown representation after rendering.
   updateMarkdownInput();
 }


### PR DESCRIPTION
## Summary
- remove the fixed node dimensions so text boxes use a maximum width and auto height
- measure rendered node sizes and recompute layout/viewBox to keep spacing and avoid clipping
- trigger redraws when content changes so branches rebalance around resized nodes

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cd56466ad8832a9f0eb639771ff79c