### PR TITLE
Add zoom controls and improve dynamic node sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,11 @@
   </section>
   <main>
     <div id="viewer">
+      <div id="zoomControls" aria-label="Zoom controls">
+        <button id="zoomInBtn" title="Zoom in">+</button>
+        <button id="zoomOutBtn" title="Zoom out">−</button>
+        <button id="resetViewBtn" title="Reset view">Reset</button>
+      </div>
       <!-- The SVG element for the mind map will be inserted here -->
       <svg id="mindmapCanvas"></svg>
     </div>

--- a/style.css
+++ b/style.css
@@ -81,8 +81,9 @@ main {
 }
 
 #viewer {
+  position: relative;
   flex: 1;
-  overflow: auto;
+  overflow: hidden;
   padding: 1rem;
   background-color: white;
 }
@@ -96,6 +97,34 @@ textarea#markdownInput {
 svg#mindmapCanvas {
   width: 100%;
   height: 100%;
+  touch-action: none;
+}
+
+#zoomControls {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  padding: 0.5rem;
+  background-color: rgba(233, 238, 245, 0.9);
+  border-radius: 8px;
+}
+
+#zoomControls button {
+  padding: 0.35rem 0.6rem;
+  border: none;
+  background-color: #4a90e2;
+  color: white;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  line-height: 1;
+}
+
+#zoomControls button:hover {
+  background-color: #357ab5;
 }
 
 @media (max-width: 800px) {


### PR DESCRIPTION
## Summary
- add inline zoom controls and styling so the viewer can pan and zoom without browser tools
- integrate d3 zoom behaviour, auto-fitting, and export adjustments to support large maps without recursive renders
- refine node sizing logic to drop fixed heights and shadows while respecting a maximum width

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d0dc1ca230832a92eef7ae57dfd015