### PR TITLE
Improve responsive editor controls

### DIFF
--- a/lib/src/screens/map_overview_page.dart
+++ b/lib/src/screens/map_overview_page.dart
@@ -231,6 +231,9 @@ class _MindMapOverviewPageState extends ConsumerState<MindMapOverviewPage> {
       _showMessage('Map "$name" was not found.');
       return;
     }
+    if (!mounted) {
+      return;
+    }
     ref.read(mindMapProvider.notifier).importFromMarkdown(markdown);
     ref.read(currentMapNameProvider.notifier).state = name;
     await Navigator.of(
@@ -405,7 +408,7 @@ class _MindMapCard extends StatelessWidget {
                 style: TextStyle(
                   color: Theme.of(
                     context,
-                  ).textTheme.bodySmall?.color?.withOpacity(0.7),
+                  ).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
                 ),
               ),
             ],

--- a/lib/src/state/mind_map_state.dart
+++ b/lib/src/state/mind_map_state.dart
@@ -136,6 +136,28 @@ class MindMapNotifier extends StateNotifier<MindMapState> {
     return newNode.id;
   }
 
+  void removeNode(String nodeId) {
+    if (state.root.id == nodeId) {
+      return;
+    }
+    final parent = _findParent(state.root, nodeId);
+    if (parent == null) {
+      return;
+    }
+    final result = _updateChildren(
+      state.root,
+      parent.id,
+      (children) => [
+        for (final child in children)
+          if (child.id != nodeId) child,
+      ],
+    );
+    if (!result.modified) {
+      return;
+    }
+    _updateState(result.node, selectedId: parent.id, autoFit: true);
+  }
+
   void importFromMarkdown(String text) {
     final parsed = _converter.fromMarkdown(text);
     if (parsed == null) {
@@ -176,6 +198,19 @@ class MindMapNotifier extends StateNotifier<MindMapState> {
       final found = _findNode(child, id);
       if (found != null) {
         return found;
+      }
+    }
+    return null;
+  }
+
+  MindMapNode? _findParent(MindMapNode node, String childId) {
+    for (final child in node.children) {
+      if (child.id == childId) {
+        return node;
+      }
+      final parent = _findParent(child, childId);
+      if (parent != null) {
+        return parent;
       }
     }
     return null;


### PR DESCRIPTION
## Summary
- redesign the editor overlay to adapt between compact and wide layouts and expose touch-friendly controls for node creation, deletion, and viewport management
- add a controller API to `MindMapView` so the editor toolbar can drive zoom and reset actions and remove the hard-coded zoom overlay
- support deleting nodes in the state notifier and resolve mobile navigation and style lints in the overview screen

## Testing
- flutter analyze
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d39c3e7b20832a849ac7e1fedc10e4