### PR TITLE
Adjust focus behavior on touch devices

### DIFF
--- a/lib/src/screens/mind_map_editor_page.dart
+++ b/lib/src/screens/mind_map_editor_page.dart
@@ -147,14 +147,13 @@ class _MindMapEditorPageState extends ConsumerState<MindMapEditorPage> {
     final state = ref.watch(mindMapProvider);
     _lastSavedMarkdown ??= state.markdown;
     final mapName = ref.watch(currentMapNameProvider) ?? widget.mapName;
-    final keyboardInset = MediaQuery.viewInsetsOf(context).bottom;
-
     return Scaffold(
+      resizeToAvoidBottomInset: false,
       body: Stack(
         children: [
           Positioned.fill(child: MindMapView(controller: _viewController)),
           _buildTopControls(mapName),
-          _buildViewControls(keyboardInset),
+          _buildViewControls(),
           _buildNodeActionBar(state),
         ],
       ),
@@ -243,13 +242,13 @@ class _MindMapEditorPageState extends ConsumerState<MindMapEditorPage> {
     );
   }
 
-  Widget _buildViewControls(double keyboardInset) {
+  Widget _buildViewControls() {
     return SafeArea(
       top: false,
       child: Align(
         alignment: Alignment.bottomCenter,
         child: Padding(
-          padding: EdgeInsets.only(bottom: 16 + keyboardInset),
+          padding: const EdgeInsets.only(bottom: 16),
           child: Row(
             mainAxisSize: MainAxisSize.min,
             children: [


### PR DESCRIPTION
## Summary
- avoid resizing the editor when the virtual keyboard appears
- skip automatic focus requests on touch-only platforms so editing requires an explicit tap
- add an explicit edit affordance (button or double tap) and block text field interactions until editing is requested on touch devices

## Testing
- flutter test

------
https://chatgpt.com/codex/tasks/task_e_68d52c8e1214832ab26f97939cb87775