### PR TITLE
Revamp UI with MindKite branding

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'package:hive_flutter/hive_flutter.dart';
 
 import 'src/screens/map_overview_page.dart';
 import 'src/state/mind_map_storage.dart';
+import 'src/theme/app_theme.dart';
+import 'src/widgets/brand_loading_screen.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -19,19 +21,40 @@ Future<void> main() async {
   );
 }
 
-class MindMapApp extends StatelessWidget {
+class MindMapApp extends StatefulWidget {
   const MindMapApp({super.key});
+
+  @override
+  State<MindMapApp> createState() => _MindMapAppState();
+}
+
+class _MindMapAppState extends State<MindMapApp> {
+  bool _showSplash = true;
+
+  @override
+  void initState() {
+    super.initState();
+    Future<void>.delayed(const Duration(milliseconds: 1400), () {
+      if (mounted) {
+        setState(() => _showSplash = false);
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      title: 'Mind Map Editor',
-      theme: ThemeData(
-        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
-        scaffoldBackgroundColor: const Color(0xFFF3F4F6),
-        useMaterial3: true,
+      title: 'MindKite',
+      debugShowCheckedModeBanner: false,
+      theme: AppTheme.light(),
+      home: AnimatedSwitcher(
+        duration: const Duration(milliseconds: 600),
+        switchInCurve: Curves.easeOutCubic,
+        switchOutCurve: Curves.easeInCubic,
+        child: _showSplash
+            ? const BrandLoadingScreen()
+            : const MindMapOverviewPage(),
       ),
-      home: const MindMapOverviewPage(),
     );
   }
 }

--- a/lib/src/models/mind_map_node.dart
+++ b/lib/src/models/mind_map_node.dart
@@ -34,5 +34,6 @@ class MindMapNode {
   }
 
   @override
-  int get hashCode => Object.hash(id, text, const DeepCollectionEquality().hash(children));
+  int get hashCode =>
+      Object.hash(id, text, const DeepCollectionEquality().hash(children));
 }

--- a/lib/src/screens/map_overview_page.dart
+++ b/lib/src/screens/map_overview_page.dart
@@ -1,8 +1,10 @@
 import 'dart:convert';
+import 'dart:ui' show ImageFilter;
 
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_svg/flutter_svg.dart';
 import 'package:uuid/uuid.dart';
 
 import '../state/current_map.dart';
@@ -10,6 +12,7 @@ import '../state/mind_map_state.dart';
 import '../state/mind_map_storage.dart';
 import '../utils/markdown_converter.dart';
 import '../utils/mindmeister_importer.dart';
+import '../theme/app_colors.dart';
 import 'mind_map_editor_page.dart';
 
 class MindMapOverviewPage extends ConsumerStatefulWidget {
@@ -25,90 +28,202 @@ class _MindMapOverviewPageState extends ConsumerState<MindMapOverviewPage> {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final savedMaps = ref.watch(savedMapsProvider);
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Your mind maps'), centerTitle: false),
-      body: SafeArea(
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Wrap(
-                spacing: 12,
-                runSpacing: 12,
+      body: Stack(
+        children: [
+          const Positioned.fill(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [AppColors.cloudWhite, Colors.white],
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                ),
+              ),
+            ),
+          ),
+          SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  ElevatedButton.icon(
-                    icon: const Icon(Icons.add_circle),
-                    label: const Text('New mind map'),
-                    onPressed: _busy ? null : _createNewMap,
+                  _buildHeroSection(theme),
+                  const SizedBox(height: 24),
+                  Wrap(
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      ElevatedButton.icon(
+                        icon: const Icon(Icons.flight_takeoff_rounded),
+                        label: const Text('New mind map'),
+                        onPressed: _busy ? null : _createNewMap,
+                      ),
+                      FilledButton.icon(
+                        icon: const Icon(Icons.file_open),
+                        label: const Text('Import text'),
+                        onPressed: _busy ? null : _importMarkdown,
+                      ),
+                      OutlinedButton.icon(
+                        icon: const Icon(Icons.cloud_upload_outlined),
+                        label: const Text('Import .mind'),
+                        onPressed: _busy ? null : _importMindFile,
+                      ),
+                    ],
                   ),
-                  ElevatedButton.icon(
-                    icon: const Icon(Icons.file_open),
-                    label: const Text('Import text'),
-                    onPressed: _busy ? null : _importMarkdown,
-                  ),
-                  ElevatedButton.icon(
-                    icon: const Icon(Icons.cloud_upload),
-                    label: const Text('Import .mind'),
-                    onPressed: _busy ? null : _importMindFile,
+                  const SizedBox(height: 24),
+                  Expanded(
+                    child: AnimatedSwitcher(
+                      duration: const Duration(milliseconds: 320),
+                      child: savedMaps.isEmpty
+                          ? _buildEmptyState(theme)
+                          : _buildSavedMapsGrid(savedMaps),
+                    ),
                   ),
                 ],
               ),
-              const SizedBox(height: 24),
-              Expanded(
-                child: savedMaps.isEmpty
-                    ? _buildEmptyState()
-                    : LayoutBuilder(
-                        builder: (context, constraints) {
-                          final columnWidth = 260.0;
-                          final count = (constraints.maxWidth / columnWidth)
-                              .floor()
-                              .clamp(1, 4);
-                          return GridView.builder(
-                            gridDelegate:
-                                SliverGridDelegateWithFixedCrossAxisCount(
-                                  crossAxisCount: count,
-                                  crossAxisSpacing: 16,
-                                  mainAxisSpacing: 16,
-                                  childAspectRatio: 1.25,
-                                ),
-                            itemCount: savedMaps.length,
-                            itemBuilder: (context, index) {
-                              final name = savedMaps[index];
-                              return _MindMapCard(
-                                name: name,
-                                onOpen: () => _openMap(name),
-                                onDelete: () => _confirmDelete(name),
-                              );
-                            },
-                          );
-                        },
-                      ),
+            ),
+          ),
+          if (_busy) const _BusyOverlay(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeroSection(ThemeData theme) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(18),
+          decoration: BoxDecoration(
+            gradient: const LinearGradient(
+              colors: [Color(0xFF6D69FF), Color(0x802AA8FF)],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(24),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.graphSlate.withOpacity(0.12),
+                blurRadius: 24,
+                offset: const Offset(0, 16),
               ),
             ],
           ),
+          child: SvgPicture.asset(
+            'assets/logo/mindkite_mark_notail_light.svg',
+            height: 48,
+            width: 48,
+          ),
+        ),
+        const SizedBox(width: 20),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Text(
+                'MindKite',
+                style: theme.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                'Let ideas fly freely.',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: theme.colorScheme.onBackground.withOpacity(0.7),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmptyState(ThemeData theme) {
+    return Center(
+      child: Container(
+        constraints: const BoxConstraints(maxWidth: 400),
+        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 40),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(28),
+          border: Border.all(color: AppColors.graphSlate.withOpacity(0.08)),
+          boxShadow: [
+            BoxShadow(
+              color: AppColors.graphSlate.withOpacity(0.08),
+              blurRadius: 32,
+              offset: const Offset(0, 18),
+            ),
+          ],
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: const EdgeInsets.all(20),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                color: theme.colorScheme.primary.withOpacity(0.12),
+              ),
+              child: Icon(
+                Icons.airplanemode_active,
+                size: 40,
+                color: theme.colorScheme.primary,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No mind maps yet',
+              style: theme.textTheme.titleLarge?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Create a new map or import one to get started.',
+              style: theme.textTheme.bodyLarge?.copyWith(
+                color: theme.colorScheme.onBackground.withOpacity(0.65),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
         ),
       ),
     );
   }
 
-  Widget _buildEmptyState() {
-    return Center(
-      child: Column(
-        mainAxisSize: MainAxisSize.min,
-        children: const [
-          Icon(Icons.account_tree_outlined, size: 64, color: Colors.grey),
-          SizedBox(height: 16),
-          Text(
-            'No mind maps yet',
-            style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+  Widget _buildSavedMapsGrid(List<String> savedMaps) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        const columnWidth = 260.0;
+        final count = (constraints.maxWidth / columnWidth).floor().clamp(1, 4);
+        return GridView.builder(
+          padding: const EdgeInsets.only(bottom: 8),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: count,
+            crossAxisSpacing: 20,
+            mainAxisSpacing: 20,
+            childAspectRatio: 1.2,
           ),
-          SizedBox(height: 8),
-          Text('Create a new map or import one to get started.'),
-        ],
-      ),
+          itemCount: savedMaps.length,
+          itemBuilder: (context, index) {
+            final name = savedMaps[index];
+            return _MindMapCard(
+              name: name,
+              onOpen: () => _openMap(name),
+              onDelete: () => _confirmDelete(name),
+            );
+          },
+        );
+      },
     );
   }
 
@@ -359,59 +474,108 @@ class _MindMapCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Card(
-      elevation: 4,
-      clipBehavior: Clip.antiAlias,
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    return Material(
+      color: Colors.transparent,
       child: InkWell(
         onTap: onOpen,
-        child: Padding(
-          padding: const EdgeInsets.all(16),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Row(
-                children: [
-                  Container(
-                    decoration: BoxDecoration(
-                      color: Theme.of(
-                        context,
-                      ).colorScheme.primary.withValues(alpha: 0.12),
-                      shape: BoxShape.circle,
+        borderRadius: BorderRadius.circular(24),
+        splashColor: colorScheme.primary.withOpacity(0.08),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(24),
+            gradient: const LinearGradient(
+              colors: [Color(0xFFE7F4FF), Colors.white],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            border: Border.all(color: colorScheme.primary.withOpacity(0.12)),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.graphSlate.withOpacity(0.08),
+                blurRadius: 28,
+                offset: const Offset(0, 18),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Container(
+                      decoration: BoxDecoration(
+                        color: colorScheme.primary.withOpacity(0.12),
+                        shape: BoxShape.circle,
+                      ),
+                      padding: const EdgeInsets.all(12),
+                      child: Icon(
+                        Icons.airplanemode_on,
+                        color: colorScheme.primary,
+                      ),
                     ),
-                    padding: const EdgeInsets.all(12),
-                    child: Icon(
-                      Icons.account_tree,
-                      color: Theme.of(context).colorScheme.primary,
+                    const Spacer(),
+                    IconButton(
+                      icon: const Icon(Icons.delete_outline),
+                      tooltip: 'Delete mind map',
+                      onPressed: onDelete,
                     ),
+                  ],
+                ),
+                const Spacer(),
+                Text(
+                  name,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
                   ),
-                  const Spacer(),
-                  IconButton(
-                    icon: const Icon(Icons.delete_outline),
-                    tooltip: 'Delete mind map',
-                    onPressed: onDelete,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Tap to open',
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: colorScheme.onBackground.withOpacity(0.6),
+                    letterSpacing: 0.2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _BusyOverlay extends StatelessWidget {
+  const _BusyOverlay();
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return Positioned.fill(
+      child: AbsorbPointer(
+        child: BackdropFilter(
+          filter: ImageFilter.blur(sigmaX: 12, sigmaY: 12),
+          child: Container(
+            color: colorScheme.background.withOpacity(0.65),
+            child: Center(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(width: 64, child: LinearProgressIndicator()),
+                  const SizedBox(height: 16),
+                  Text(
+                    'Importing…',
+                    style: Theme.of(context).textTheme.bodyMedium,
                   ),
                 ],
               ),
-              const Spacer(),
-              Text(
-                name,
-                style: const TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.w600,
-                ),
-                maxLines: 2,
-                overflow: TextOverflow.ellipsis,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                'Tap to open',
-                style: TextStyle(
-                  color: Theme.of(
-                    context,
-                  ).textTheme.bodySmall?.color?.withValues(alpha: 0.7),
-                ),
-              ),
-            ],
+            ),
           ),
         ),
       ),

--- a/lib/src/screens/mind_map_editor_page.dart
+++ b/lib/src/screens/mind_map_editor_page.dart
@@ -14,6 +14,7 @@ import '../state/node_edit_request.dart';
 import '../utils/constants.dart';
 import '../utils/svg_exporter.dart';
 import '../widgets/mind_map_view.dart';
+import '../theme/app_colors.dart';
 
 class MindMapEditorPage extends ConsumerStatefulWidget {
   const MindMapEditorPage({super.key, required this.mapName});
@@ -150,13 +151,22 @@ class _MindMapEditorPageState extends ConsumerState<MindMapEditorPage> {
     final mapName = ref.watch(currentMapNameProvider) ?? widget.mapName;
     return Scaffold(
       resizeToAvoidBottomInset: false,
-      body: Stack(
-        children: [
-          Positioned.fill(child: MindMapView(controller: _viewController)),
-          _buildTopControls(mapName),
-          _buildViewControls(),
-          _buildNodeActionBar(state),
-        ],
+      body: DecoratedBox(
+        decoration: const BoxDecoration(
+          gradient: LinearGradient(
+            colors: [AppColors.cloudWhite, Colors.white],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Stack(
+          children: [
+            Positioned.fill(child: MindMapView(controller: _viewController)),
+            _buildTopControls(mapName),
+            _buildViewControls(),
+            _buildNodeActionBar(state),
+          ],
+        ),
       ),
     );
   }
@@ -179,65 +189,88 @@ class _MindMapEditorPageState extends ConsumerState<MindMapEditorPage> {
   }
 
   Widget _buildHeader(String mapName, {required bool showName}) {
-    return Material(
-      color: Colors.white,
-      elevation: 6,
-      borderRadius: BorderRadius.circular(16),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-        child: Row(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            IconButton(
-              icon: const Icon(Icons.arrow_back),
-              tooltip: 'Back to overview',
-              onPressed: () {
-                Navigator.of(context).pop();
-              },
-            ),
-            if (showName) ...[
-              const SizedBox(width: 8),
-              ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 320),
-                child: Text(
-                  mapName,
-                  style: const TextStyle(
-                    fontSize: 16,
-                    fontWeight: FontWeight.bold,
-                  ),
-                  overflow: TextOverflow.ellipsis,
-                ),
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.graphSlate.withOpacity(0.12),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Material(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.arrow_back),
+                tooltip: 'Back to overview',
+                onPressed: () {
+                  Navigator.of(context).pop();
+                },
               ),
+              if (showName) ...[
+                const SizedBox(width: 12),
+                ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 320),
+                  child: Text(
+                    mapName,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
             ],
-          ],
+          ),
         ),
       ),
     );
   }
 
   Widget _buildToolbar() {
-    return Material(
-      color: Colors.white,
-      elevation: 6,
-      borderRadius: BorderRadius.circular(16),
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 4),
-        child: Wrap(
-          spacing: 4,
-          runSpacing: 4,
-          alignment: WrapAlignment.end,
-          children: [
-            IconButton(
-              icon: const Icon(Icons.file_download),
-              tooltip: 'Export text',
-              onPressed: _exportMarkdown,
-            ),
-            IconButton(
-              icon: const Icon(Icons.image),
-              tooltip: 'Export SVG',
-              onPressed: _exportSvg,
-            ),
-          ],
+    final theme = Theme.of(context);
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.graphSlate.withOpacity(0.12),
+            blurRadius: 24,
+            offset: const Offset(0, 12),
+          ),
+        ],
+      ),
+      child: Material(
+        color: theme.colorScheme.surface,
+        borderRadius: BorderRadius.circular(20),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 6),
+          child: Wrap(
+            spacing: 4,
+            runSpacing: 4,
+            alignment: WrapAlignment.end,
+            children: [
+              IconButton(
+                icon: const Icon(Icons.file_download),
+                tooltip: 'Export text',
+                onPressed: _exportMarkdown,
+              ),
+              IconButton(
+                icon: const Icon(Icons.image_outlined),
+                tooltip: 'Export SVG',
+                onPressed: _exportSvg,
+              ),
+            ],
+          ),
         ),
       ),
     );
@@ -371,6 +404,7 @@ class _MindMapEditorPageState extends ConsumerState<MindMapEditorPage> {
       backgroundColor: backgroundColor,
       foregroundColor: foregroundColor,
       tooltip: tooltip,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Icon(icon),
     );
   }

--- a/lib/src/theme/app_colors.dart
+++ b/lib/src/theme/app_colors.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+
+class AppColors {
+  const AppColors._();
+
+  static const Color primarySky = Color(0xFF2AA8FF);
+  static const Color nightNavy = Color(0xFF0B1220);
+  static const Color cloudWhite = Color(0xFFF7FAFF);
+  static const Color lavenderLift = Color(0xFF9AA6FF);
+  static const Color graphSlate = Color(0xFF334155);
+
+  static const Gradient heroGradient = LinearGradient(
+    colors: [Color(0xFF6D69FF), Color(0xFF00E5FF)],
+    begin: Alignment.topLeft,
+    end: Alignment.bottomRight,
+  );
+}

--- a/lib/src/theme/app_theme.dart
+++ b/lib/src/theme/app_theme.dart
@@ -1,0 +1,172 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import 'app_colors.dart';
+
+class AppTheme {
+  const AppTheme._();
+
+  static ThemeData light() {
+    final base = ThemeData(brightness: Brightness.light, useMaterial3: true);
+    final colorScheme =
+        ColorScheme.fromSeed(
+          seedColor: AppColors.primarySky,
+          brightness: Brightness.light,
+        ).copyWith(
+          primary: AppColors.primarySky,
+          onPrimary: Colors.white,
+          secondary: AppColors.lavenderLift,
+          onSecondary: AppColors.nightNavy,
+          surface: Colors.white,
+          onSurface: AppColors.nightNavy,
+          background: AppColors.cloudWhite,
+          onBackground: AppColors.nightNavy,
+          outline: AppColors.graphSlate,
+        );
+
+    final baseTextTheme = base.textTheme;
+    final interTextTheme = GoogleFonts.interTextTheme(baseTextTheme).apply(
+      bodyColor: colorScheme.onBackground,
+      displayColor: colorScheme.onBackground,
+    );
+    final displayTheme = GoogleFonts.spaceGroteskTextTheme(baseTextTheme).apply(
+      bodyColor: colorScheme.onBackground,
+      displayColor: colorScheme.onBackground,
+    );
+
+    final textTheme = interTextTheme.copyWith(
+      displayLarge: displayTheme.displayLarge,
+      displayMedium: displayTheme.displayMedium,
+      displaySmall: displayTheme.displaySmall,
+      headlineLarge: displayTheme.headlineLarge,
+      headlineMedium: displayTheme.headlineMedium,
+      headlineSmall: displayTheme.headlineSmall,
+      titleLarge: displayTheme.titleLarge,
+      titleMedium: displayTheme.titleMedium,
+      titleSmall: displayTheme.titleSmall,
+      labelLarge: interTextTheme.labelLarge?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+      labelMedium: interTextTheme.labelMedium?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+      labelSmall: interTextTheme.labelSmall?.copyWith(
+        fontWeight: FontWeight.w600,
+      ),
+    );
+
+    final cardShape = RoundedRectangleBorder(
+      borderRadius: BorderRadius.circular(20),
+    );
+
+    return base.copyWith(
+      colorScheme: colorScheme,
+      scaffoldBackgroundColor: AppColors.cloudWhite,
+      textTheme: textTheme,
+      appBarTheme: AppBarTheme(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        scrolledUnderElevation: 0,
+        centerTitle: false,
+        foregroundColor: colorScheme.onBackground,
+        titleTextStyle: textTheme.titleLarge?.copyWith(
+          fontWeight: FontWeight.w700,
+          color: colorScheme.onBackground,
+        ),
+      ),
+      cardTheme: CardThemeData(
+        elevation: 6,
+        shadowColor: AppColors.graphSlate.withOpacity(0.08),
+        shape: cardShape,
+        surfaceTintColor: Colors.white,
+      ),
+      snackBarTheme: SnackBarThemeData(
+        backgroundColor: colorScheme.onBackground,
+        contentTextStyle: textTheme.bodyMedium?.copyWith(color: Colors.white),
+        behavior: SnackBarBehavior.floating,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      ),
+      elevatedButtonTheme: ElevatedButtonThemeData(
+        style: ElevatedButton.styleFrom(
+          backgroundColor: AppColors.primarySky,
+          foregroundColor: Colors.white,
+          textStyle: textTheme.labelLarge,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
+          backgroundColor: colorScheme.secondary,
+          foregroundColor: colorScheme.onSecondary,
+          textStyle: textTheme.labelLarge,
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+      outlinedButtonTheme: OutlinedButtonThemeData(
+        style: OutlinedButton.styleFrom(
+          foregroundColor: colorScheme.primary,
+          textStyle: textTheme.labelLarge,
+          side: BorderSide(color: colorScheme.primary.withOpacity(0.4)),
+          padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(16),
+          ),
+        ),
+      ),
+      iconButtonTheme: IconButtonThemeData(
+        style: IconButton.styleFrom(
+          foregroundColor: colorScheme.onBackground,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.all(10),
+        ),
+      ),
+      floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: AppColors.primarySky,
+        foregroundColor: Colors.white,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      ),
+      dialogTheme: DialogThemeData(
+        shape: cardShape,
+        backgroundColor: Colors.white,
+        surfaceTintColor: Colors.white,
+        titleTextStyle: textTheme.titleLarge,
+        contentTextStyle: textTheme.bodyMedium,
+      ),
+      inputDecorationTheme: InputDecorationTheme(
+        filled: true,
+        fillColor: Colors.white,
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: colorScheme.outline.withOpacity(0.2)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(16),
+          borderSide: BorderSide(color: colorScheme.primary, width: 1.5),
+        ),
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: 20,
+          vertical: 16,
+        ),
+      ),
+      dividerTheme: DividerThemeData(
+        color: colorScheme.outline.withOpacity(0.12),
+        thickness: 1,
+        space: 24,
+      ),
+      chipTheme: ChipThemeData(
+        backgroundColor: colorScheme.primary.withOpacity(0.1),
+        labelStyle: textTheme.bodyMedium,
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+      visualDensity: VisualDensity.adaptivePlatformDensity,
+    );
+  }
+}

--- a/lib/src/utils/constants.dart
+++ b/lib/src/utils/constants.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
 
 const double nodeMaxWidth = 240;
 const double nodeMinWidth = 80;
@@ -18,17 +19,18 @@ const double zoomMaxScale = 3.0;
 const double boundsMargin = 80;
 const double focusViewportMargin = 96;
 
-const textStyle = TextStyle(fontSize: 16, height: 1.3, color: Colors.black87);
+const textStyle = TextStyle(
+  fontSize: 16,
+  height: 1.3,
+  color: AppColors.nightNavy,
+  fontFamily: 'Inter',
+);
 
 const List<Color> branchColors = [
-  Color(0xFFF44336),
-  Color(0xFF9C27B0),
-  Color(0xFF2196F3),
-  Color(0xFF4CAF50),
-  Color(0xFFFF9800),
-  Color(0xFF795548),
-  Color(0xFF00BCD4),
-  Color(0xFF607D8B),
-  Color(0xFFE91E63),
-  Color(0xFF3F51B5),
+  AppColors.primarySky,
+  Color(0xFF6D69FF),
+  AppColors.lavenderLift,
+  Color(0xFF00E5FF),
+  Color(0xFF7BCBFF),
+  AppColors.graphSlate,
 ];

--- a/lib/src/utils/mindmeister_importer.dart
+++ b/lib/src/utils/mindmeister_importer.dart
@@ -22,7 +22,8 @@ class MindmeisterImporter {
       if (json.containsKey('root') && json['root'] is Map<String, dynamic>) {
         return json['root'] as Map<String, dynamic>;
       }
-      if (json.containsKey('mindmap') && json['mindmap'] is Map<String, dynamic>) {
+      if (json.containsKey('mindmap') &&
+          json['mindmap'] is Map<String, dynamic>) {
         final map = json['mindmap'] as Map<String, dynamic>;
         if (map.containsKey('root') && map['root'] is Map<String, dynamic>) {
           return map['root'] as Map<String, dynamic>;

--- a/lib/src/utils/svg_exporter.dart
+++ b/lib/src/utils/svg_exporter.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import '../layout/mind_map_layout.dart';
+import '../theme/app_colors.dart';
 import 'constants.dart';
 
 class SvgExporter {
@@ -13,8 +14,14 @@ class SvgExporter {
     final buffer = StringBuffer();
     final width = bounds.width == 0 ? 1 : bounds.width;
     final height = bounds.height == 0 ? 1 : bounds.height;
-    buffer.writeln('<svg xmlns="http://www.w3.org/2000/svg" viewBox="${bounds.left} ${bounds.top} $width $height">');
-    buffer.writeln('<defs><style>.node-text{font-family:Helvetica,Arial,sans-serif;font-size:${textStyle.fontSize}px;fill:#333;}</style></defs>');
+    buffer.writeln(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="${bounds.left} ${bounds.top} $width $height">',
+    );
+    final textColor = _colorHex(AppColors.nightNavy);
+    final cardFill = _colorHex(AppColors.cloudWhite);
+    buffer.writeln(
+      '<defs><style>.node-text{font-family:"Inter","Helvetica Neue",Arial,sans-serif;font-size:${textStyle.fontSize}px;fill:$textColor;}</style></defs>',
+    );
 
     for (final data in layout.nodes.values) {
       if (data.parentId == null) {
@@ -24,12 +31,21 @@ class SvgExporter {
       if (parent == null) {
         continue;
       }
-      final color = _colorHex(branchColors[(data.branchIndex >= 0 ? data.branchIndex : 0) % branchColors.length]);
-      final startX = parent.center.dx + (data.isLeft ? -parent.size.width / 2 : parent.size.width / 2);
+      final color = _colorHex(
+        branchColors[(data.branchIndex >= 0 ? data.branchIndex : 0) %
+            branchColors.length],
+      );
+      final startX =
+          parent.center.dx +
+          (data.isLeft ? -parent.size.width / 2 : parent.size.width / 2);
       final startY = parent.center.dy;
-      final endX = data.center.dx + (data.isLeft ? data.size.width / 2 : -data.size.width / 2);
+      final endX =
+          data.center.dx +
+          (data.isLeft ? data.size.width / 2 : -data.size.width / 2);
       final endY = data.center.dy;
-      final control = data.isLeft ? -nodeHorizontalGap / 2 : nodeHorizontalGap / 2;
+      final control = data.isLeft
+          ? -nodeHorizontalGap / 2
+          : nodeHorizontalGap / 2;
       buffer.writeln(
         '<path d="M $startX $startY C ${startX + control} $startY ${endX - control} $endY $endX $endY" stroke="$color" stroke-width="2" fill="none"/>',
       );
@@ -37,17 +53,22 @@ class SvgExporter {
 
     final lineHeight = (textStyle.fontSize ?? 16) * (textStyle.height ?? 1.3);
     for (final data in layout.nodes.values) {
-      final stroke = _colorHex(branchColors[(data.branchIndex >= 0 ? data.branchIndex : 0) % branchColors.length]);
+      final stroke = _colorHex(
+        branchColors[(data.branchIndex >= 0 ? data.branchIndex : 0) %
+            branchColors.length],
+      );
       final rectX = data.topLeft.dx;
       final rectY = data.topLeft.dy;
       buffer.writeln(
-        '<rect x="$rectX" y="$rectY" width="${data.size.width}" height="${data.size.height}" rx="16" ry="16" fill="#ffffff" stroke="$stroke" stroke-width="1.5"/>',
+        '<rect x="$rectX" y="$rectY" width="${data.size.width}" height="${data.size.height}" rx="16" ry="16" fill="$cardFill" stroke="$stroke" stroke-width="1.5"/>',
       );
       var textY = rectY + nodeVerticalPadding + (textStyle.fontSize ?? 16);
       final textX = data.center.dx;
       for (final line in data.lines) {
         final escaped = _escape(line);
-        buffer.writeln('<text x="$textX" y="$textY" text-anchor="middle" class="node-text">$escaped</text>');
+        buffer.writeln(
+          '<text x="$textX" y="$textY" text-anchor="middle" class="node-text">$escaped</text>',
+        );
         textY += lineHeight;
       }
     }

--- a/lib/src/widgets/brand_loading_screen.dart
+++ b/lib/src/widgets/brand_loading_screen.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+
+import '../theme/app_colors.dart';
+
+class BrandLoadingScreen extends StatelessWidget {
+  const BrandLoadingScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: Colors.transparent,
+      body: DecoratedBox(
+        decoration: const BoxDecoration(gradient: AppColors.heroGradient),
+        child: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(32),
+                  decoration: BoxDecoration(
+                    color: Colors.white.withOpacity(0.12),
+                    borderRadius: BorderRadius.circular(32),
+                    border: Border.all(
+                      color: Colors.white.withOpacity(0.25),
+                      width: 1.5,
+                    ),
+                    boxShadow: const [
+                      BoxShadow(
+                        color: Colors.black26,
+                        blurRadius: 32,
+                        offset: Offset(0, 12),
+                      ),
+                    ],
+                  ),
+                  child: SvgPicture.asset(
+                    'assets/logo/mindkite_mark_notail_light.svg',
+                    width: 96,
+                    height: 96,
+                  ),
+                ),
+                const SizedBox(height: 32),
+                Text(
+                  'MindKite',
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.w700,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  'Let ideas fly freely.',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    color: Colors.white.withOpacity(0.85),
+                    letterSpacing: 0.4,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
+                const SizedBox(height: 40),
+                const SizedBox(
+                  width: 72,
+                  child: LinearProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    backgroundColor: Colors.white24,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/widgets/node_card.dart
+++ b/lib/src/widgets/node_card.dart
@@ -7,6 +7,7 @@ import '../layout/mind_map_layout.dart';
 import '../state/layout_snapshot.dart';
 import '../state/mind_map_state.dart';
 import '../state/node_edit_request.dart';
+import '../theme/app_colors.dart';
 import '../utils/constants.dart';
 
 typedef FocusOnNodeCallback = void Function(String id, {bool preferTopHalf});
@@ -299,8 +300,12 @@ class _MindMapNodeCardState extends ConsumerState<MindMapNodeCard> {
 
   @override
   Widget build(BuildContext context) {
-    final highlight = widget.isSelected ? widget.accentColor : Colors.black12;
-    final shadowColor = Colors.black.withValues(alpha: Colors.black.a * 0.06);
+    final theme = Theme.of(context);
+    final borderColor = widget.isSelected
+        ? widget.accentColor
+        : theme.colorScheme.primary.withOpacity(0.14);
+    final shadowColor = AppColors.graphSlate.withOpacity(0.08);
+    final backgroundColor = theme.colorScheme.surface;
     final isTouchOnly = _isTouchOnlyDevice();
     final ignoreTextInput = isTouchOnly && !_focusNode.hasFocus;
     return GestureDetector(
@@ -313,10 +318,10 @@ class _MindMapNodeCardState extends ConsumerState<MindMapNodeCard> {
         children: [
           DecoratedBox(
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: backgroundColor,
               borderRadius: BorderRadius.circular(16),
               border: Border.all(
-                color: highlight,
+                color: borderColor,
                 width: widget.isSelected
                     ? nodeSelectedBorderWidth
                     : nodeBorderWidth,
@@ -345,7 +350,7 @@ class _MindMapNodeCardState extends ConsumerState<MindMapNodeCard> {
                   minLines: null,
                   keyboardType: TextInputType.multiline,
                   textAlign: TextAlign.center,
-                  style: textStyle,
+                  style: textStyle.copyWith(color: theme.colorScheme.onSurface),
                   decoration: const InputDecoration(
                     border: InputBorder.none,
                     isCollapsed: true,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.6.1"
+  args:
+    dependency: transitive
+    description:
+      name: args
+      sha256: d0481093c50b1da8910eb0bb301626d4d8eb7284aa739614d2b394ee09e3ea04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
   async:
     dependency: transitive
     description:
@@ -142,6 +150,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.1"
+  flutter_svg:
+    dependency: "direct main"
+    description:
+      name: flutter_svg
+      sha256: b9c2ad5872518a27507ab432d1fb97e8813b05f0fc693f9d40fad06d073e0678
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -152,6 +168,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "517b20870220c48752eafa0ba1a797a092fb22df0d89535fd9991e86ee2cdd9c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.2"
   hive:
     dependency: "direct main"
     description:
@@ -176,6 +200,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.15.6"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: bb2ce4590bc2667c96f318d68cac1b5a7987ec819351d32b1c987239a815e007
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -240,6 +280,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  path_parsing:
+    dependency: transitive
+    description:
+      name: path_parsing
+      sha256: "883402936929eac138ee0a45da5b0f2c80f89913e6dc3bf77eb65b84b409c6ca"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
   path_provider:
     dependency: transitive
     description:
@@ -288,6 +336,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "1a97266a94f7350d30ae522c0af07890c70b8e62c71e8e3920d1db4d23c057d1"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   platform:
     dependency: transitive
     description:
@@ -413,6 +469,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.1"
+  vector_graphics:
+    dependency: transitive
+    description:
+      name: vector_graphics
+      sha256: a4f059dc26fc8295b5921376600a194c4ec7d55e72f2fe4c7d2831e103d461e6
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
+  vector_graphics_codec:
+    dependency: transitive
+    description:
+      name: vector_graphics_codec
+      sha256: "99fd9fbd34d9f9a32efd7b6a6aae14125d8237b10403b422a6a6dfeac2806146"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.13"
+  vector_graphics_compiler:
+    dependency: transitive
+    description:
+      name: vector_graphics_compiler
+      sha256: d354a7ec6931e6047785f4db12a1f61ec3d43b207fc0790f863818543f8ff0dc
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.19"
   vector_math:
     dependency: "direct main"
     description:
@@ -453,6 +533,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: "971043b3a0d3da28727e40ed3e0b5d18b742fa5a68665cca88e74b7876d5e025"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.6.1"
 sdks:
   dart: ">=3.9.2 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,6 +41,8 @@ dependencies:
   hive_flutter: ^1.1.0
   universal_html: ^2.2.4
   vector_math: ^2.1.4
+  flutter_svg: ^2.0.10+1
+  google_fonts: ^6.2.1
 
 dev_dependencies:
   flutter_test:
@@ -63,6 +65,9 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+
+  assets:
+    - assets/logo/
 
   # To add assets to your application, add an assets section, like this:
   # assets:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -34,7 +34,10 @@ void main() {
     );
 
     await tester.pump(const Duration(milliseconds: 500));
+    await tester.pump(const Duration(milliseconds: 1200));
+    await tester.pumpAndSettle();
 
-    expect(find.text('Your mind maps'), findsOneWidget);
+    expect(find.text('MindKite'), findsOneWidget);
+    expect(find.text('Let ideas fly freely.'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- integrate the MindKite color system, fonts, and splash experience into the app shell
- restyle the overview, editor, and node components to reflect the new brand visuals
- update shared constants, SVG export styling, tests, and assets to support the refreshed UI

## Testing
- flutter test


------
https://chatgpt.com/codex/tasks/task_e_68da45d35424832a9018c9d4b17ff7d5